### PR TITLE
chore: Add license name into a Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Conversion to/from a file path from/to slash path"
 repository = "https://github.com/rhysd/path-slash"
 readme = "README.md"
+license = "MIT"
 license-file = "LICENSE.txt"
 categories = ["filesystem"]
 


### PR DESCRIPTION
Otherwise, it is not possible to easily parse license name.