### PR TITLE
Improve main documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
-//! A library for converting file paths from/to slash paths
+//! A library for converting file paths to and from "slash paths."
 //!
-//! A slash path is a path whose components are separated by separator '/' always.
+//! A "slash path" is a path whose components are always separated by `/` and never `\`.
 //!
-//! In Unix-like OS, path separator is slash '/' by default. So any conversion is not necessary.
-//! But on Windows, file path separator '\' needs to be replaced with slash '/' (and of course '\'
-//! for escaping character should not be replaced).
+//! In Unix-like Oes, the path separator is `/` by default. So any conversion is not necessary.
+//! But on Windows, the file path separator is `\`, and needs to be replaced with `/`. Of course, `\`s used
+//! for escaping characters should not be replaced.
 //!
-//! For example, a file path 'foo\bar\piyo.txt' can be converted to/from a slash path 'foo/bar/piyo.txt'
+//! For example, a file path `foo\bar\piyo.txt` can be converted to/from a slash path `foo/bar/piyo.txt`.
 //!
 //! This package was inspired by Go's `path/filepath.FromSlash` and `path/filepath.ToSlash`.
+//!
 //! - https://golang.org/pkg/path/filepath/#FromSlash
 //! - https://golang.org/pkg/path/filepath/#ToSlash
 //!


### PR DESCRIPTION
Hi there! I was using your library today, and I noticed this:

![image](https://user-images.githubusercontent.com/27786/86144561-73a40080-babb-11ea-9563-5dac3508975a.png)

The `\`s aren't rendering properly, which is kind of funny, because that's exactly why this library exists!

The library works great for me, so I figured I'd send you a PR to fix this to say thank you :) I fixed it by using ` so that it renders properly. I also did some small editing of the words too. Now it looks like this:

![image](https://user-images.githubusercontent.com/27786/86144703-a0581800-babb-11ea-837b-be236ee11867.png)

Thank you for your library!